### PR TITLE
Reset Module No Longer Leaves Blank Module UI

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -30,8 +30,9 @@
 /obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
 	if(..())
 		return
-
 	R.reset_module()
+	R.shown_robot_modules = 0
+	R.client.screen -= R.robot_modules_background
 	return TRUE
 
 /obj/item/borg/upgrade/rename


### PR DESCRIPTION
## What Does This PR Do
Tackles issue #15341, where the Reset Module could leave a Cyborg with a blank UI remaining open. If the Cyborg had their inventory toggled. This closes the module inventory on reset, allowing for a simple click to select their new module. Versus having to close the blank slate, and click again to select the module.

## Why It's Good For The Game
Closes the empty box module for Robots when they're reset. 

## Images of changes
![SUdsDHm5pH](https://user-images.githubusercontent.com/78467505/107884615-f08fc780-6f30-11eb-8484-7ee408da05bd.gif)

## Changelog
:cl:
fix: Cyborgs no longer have a blank module on display if they left the interface open when being reset.
/:cl:

fixes #15341